### PR TITLE
Specify dependencies in qrb.gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem "citrus", "~> 2.4"
+gemspec
 
 group :development do
   gem "rake", "~> 10.0"

--- a/qrb.gemspec
+++ b/qrb.gemspec
@@ -116,6 +116,7 @@ Gem::Specification.new do |s|
   #   "~> 2.2"                (shortcut for ">= 2.2.0", "< 3.0")
   #   "~> 2.2.0"              (shortcut for ">= 2.2.0", "< 2.3.0")
   #
+  s.add_dependency("citrus", "~> 2.4")
 
   #
   # One call to add_dependency('gem_name', 'gem version requirement') for each
@@ -123,8 +124,7 @@ Gem::Specification.new do |s|
   # One call to add_development_dependency('gem_name', 'gem version requirement')
   # for each development dependency. These gems are required for developers
   #
-  s.add_development_dependency("rake", "~> 10.0")
-  s.add_development_dependency("rspec", "~> 2.14")
+  # We use Gemfile for development dependencies.
   
 
   # The version of ruby required by this gem


### PR DESCRIPTION
I got this when I tried to install qrb:

```
$ gem install qrb
Fetching: qrb-0.1.0.gem (100%)
Successfully installed qrb-0.1.0
Parsing documentation for qrb-0.1.0
Installing ri documentation for qrb-0.1.0
Done installing documentation for qrb after 0 seconds
1 gem installed
~ $ pry -rqrb
/Users/magnus/.rubies/ruby-2.1.0/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- citrus (LoadError)
```
